### PR TITLE
Fix/serializer-for-today's-pick

### DIFF
--- a/server/contents/serializers.py
+++ b/server/contents/serializers.py
@@ -11,10 +11,18 @@ class ContentsInfoSerializer(serializers.ModelSerializer):
         fields = ["id", "title", "userInfo", "image", "views", "date", "category"]
 
 
+class TodayPickContentsSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Content
+        fields = ["id", "title", "image"]
+
+
 class TodayPickSerializer(serializers.ModelSerializer):
+    content = TodayPickContentsSerializer(read_only=True)
+
     class Meta:
         model = TodayPick
-        fields = ["content", "date"]
+        fields = ["content"]
 
 
 class QnASerializer(serializers.ModelSerializer):

--- a/server/contents/views.py
+++ b/server/contents/views.py
@@ -12,10 +12,17 @@ from .serializers import (
 )
 
 
-class GetTodayPickView(ListAPIView):
-    """Return today's pick instance."""
-    serializer_class = TodayPickSerializer
-    queryset = TodayPick.objects.all()
+class GetTodayPickView(APIView):
+    def get(self, request):
+        """Return today's pick content: the newest instance."""
+        try:
+            newest_instance = TodayPick.objects.latest("date")
+            serializer = TodayPickSerializer(newest_instance)
+            return Response(serializer.data)
+        except TodayPick.DoesNotExist:
+            return Response(
+                {"message": "No records found."}, status=status.HTTP_404_NOT_FOUND
+            )
 
 
 class PopularContentsListView(ListAPIView):

--- a/server/contents/views.py
+++ b/server/contents/views.py
@@ -1,5 +1,8 @@
 from rest_framework.generics import ListAPIView, RetrieveAPIView
 from rest_framework.pagination import PageNumberPagination
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status
 
 from .models import Content, TodayPick
 from .serializers import (
@@ -10,6 +13,7 @@ from .serializers import (
 
 
 class GetTodayPickView(ListAPIView):
+    """Return today's pick instance."""
     serializer_class = TodayPickSerializer
     queryset = TodayPick.objects.all()
 


### PR DESCRIPTION
Changes:
1. Added a serializer specifically for today's pick content.
2. The API now returns the content's id, title, and image.